### PR TITLE
#9 BE Github OAuth Login api 구현

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');
+const passport = require('passport');
 require('dotenv').config();
 
 const indexRouter = require('./routes/index');
@@ -15,6 +16,8 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(passport.initialize());
+require('./lib/passport');
 
 app.use('/', indexRouter);
 

--- a/backend/lib/passport.js
+++ b/backend/lib/passport.js
@@ -5,17 +5,17 @@ const { User } = require('../models');
 passport.use(new GitHubStrategy({
   clientID: process.env.GITHUB_CLIENT_ID,
   clientSecret: process.env.GITHUB_CLIENT_SECRET,
-  callbackURL: 'http://127.0.0.1:3000/users/github-login/callback',
+  callbackURL: `${process.env.SERVER_HOST}/users/github-login/callback`,
   scope: ['user:email'],
 },
 (async (accessToken, refreshToken, profile, cb) => {
   const {
     // eslint-disable-next-line camelcase
-    id, emails: [emails], username, _json: { avatar_url },
+    id, emails: [email], username, _json: { avatar_url },
   } = profile;
   try {
     const [user] = await User.findOrCreate({
-      where: { email: emails.value },
+      where: { email: email.value },
       defaults: {
         password: id, nickname: username, account_type: 'github', profile_url: avatar_url,
       },

--- a/backend/lib/passport.js
+++ b/backend/lib/passport.js
@@ -1,0 +1,27 @@
+const passport = require('passport');
+const GitHubStrategy = require('passport-github2').Strategy;
+const { User } = require('../models');
+
+passport.use(new GitHubStrategy({
+  clientID: process.env.GITHUB_CLIENT_ID,
+  clientSecret: process.env.GITHUB_CLIENT_SECRET,
+  callbackURL: 'http://127.0.0.1:3000/users/github-login/callback',
+  scope: ['user:email'],
+},
+(async (accessToken, refreshToken, profile, cb) => {
+  const {
+    // eslint-disable-next-line camelcase
+    id, emails: [emails], username, _json: { avatar_url },
+  } = profile;
+  try {
+    const [user] = await User.findOrCreate({
+      where: { email: emails.value },
+      defaults: {
+        password: id, nickname: username, account_type: 'github', profile_url: avatar_url,
+      },
+    });
+    return cb(null, user);
+  } catch (err) {
+    return cb(err);
+  }
+})));

--- a/backend/middlewares/auth.js
+++ b/backend/middlewares/auth.js
@@ -1,0 +1,19 @@
+const jwt = require('jsonwebtoken');
+const { User } = require('../models');
+
+exports.authMiddleware = async (req, res, next) => {
+  const token = req.cookies.authorization;
+  if (token) {
+    try {
+      const decoded = jwt.verify(token, process.env.JWT_SECRET);
+      const user = await User.findOne({ where: { email: decoded.email } });
+      if (user) {
+        res.locals.user = user;
+        return next();
+      }
+    } catch (err) {
+      return next(err);
+    }
+  }
+  return res.status(401).json({ success: false, message: 'Invalid or Expired Token Error' });
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -233,6 +233,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -1688,6 +1693,11 @@
         }
       }
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
@@ -1856,6 +1866,48 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "passport": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-github": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/passport-github/-/passport-github-1.1.0.tgz",
+      "integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
+      "requires": {
+        "passport-strategy": "1.x.x"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
+      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1890,6 +1942,11 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pify": {
       "version": "2.3.0",
@@ -2467,6 +2524,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "umzug": {
       "version": "2.3.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -287,6 +287,11 @@
         "concat-map": "0.0.1"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -538,6 +543,14 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "editorconfig": {
       "version": "0.15.3",
@@ -1456,6 +1469,49 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1491,6 +1547,41 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "long": {
       "version": "4.0.0",
@@ -1879,6 +1970,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/passport-github/-/passport-github-1.1.0.tgz",
       "integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-github2": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",
+      "integrity": "sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==",
       "requires": {
         "passport-oauth2": "1.x.x"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,10 +10,12 @@
     "debug": "~2.6.9",
     "dotenv": "^8.2.0",
     "express": "~4.16.1",
+    "jsonwebtoken": "^8.5.1",
     "morgan": "~1.9.1",
     "mysql2": "^2.2.5",
     "passport": "^0.4.1",
     "passport-github": "^1.1.0",
+    "passport-github2": "^0.1.12",
     "passport-local": "^1.0.0",
     "sequelize": "^6.3.5",
     "sequelize-cli": "^6.2.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,9 @@
     "express": "~4.16.1",
     "morgan": "~1.9.1",
     "mysql2": "^2.2.5",
+    "passport": "^0.4.1",
+    "passport-github": "^1.1.0",
+    "passport-local": "^1.0.0",
     "sequelize": "^6.3.5",
     "sequelize-cli": "^6.2.0"
   },

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -2,12 +2,12 @@ const express = require('express');
 
 const router = express.Router();
 
-// const userRouter = require('./users');
+const userRouter = require('./users');
 // const labelRouter = require('./labels');
 // const milestoneRouter = require('./milestones');
 // const issueRouter = require('./issues');
 
-// router.use('/users', userRouter);
+router.use('/users', userRouter);
 // router.use('/labels', labelRouter);
 // router.use('/milestones', milestoneRouter);
 // router.use('/issues', issueRouter);

--- a/backend/routes/users/index.js
+++ b/backend/routes/users/index.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const userController = require('./users.controller');
+const { authMiddleware } = require('../../middlewares/auth');
 
 const router = express.Router();
 
-router.get('/', userController.getAllUsers);
+router.get('/', authMiddleware, userController.getAllUsers);
 router.get('/github-login', userController.githubLogin);
 router.get('/github-login/callback', userController.githubLoginCallback);
 

--- a/backend/routes/users/index.js
+++ b/backend/routes/users/index.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const userController = require('./users.controller');
+
+const router = express.Router();
+
+router.get('/', userController.getAllUsers);
+router.get('/github-login', userController.githubLogin);
+router.get('/github-login/callback', userController.githubLoginCallback);
+
+module.exports = router;

--- a/backend/routes/users/users.controller.js
+++ b/backend/routes/users/users.controller.js
@@ -1,0 +1,27 @@
+const passport = require('passport');
+const jwt = require('jsonwebtoken');
+const { User } = require('../../models');
+
+exports.getAllUsers = async (req, res, next) => {
+  try {
+    const users = await User.findAll();
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ success: false, message: 'Error' });
+  }
+};
+
+exports.githubLogin = passport.authenticate('github', { scope: ['user:email'] });
+
+exports.githubLoginCallback = (req, res, next) => {
+  passport.authenticate('github', { session: false }, (err, user, info) => {
+    if (err || !user) return res.redirect('/users/login');
+
+    const payload = { userId: user.id, email: user.email };
+    const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1d' });
+
+    const options = { httpOnly: true };
+    res.cookie('authorization', token, options);
+    return res.redirect('/');
+  })(req, res, next);
+};


### PR DESCRIPTION
## 개요
GitHub OAuth 로그인을 지원하도록 api 구현

## 구현 내용 설명
- 로그인에 성공할 경우 클라이언트에게 Github OAuth 토큰을 발행
- **GET /users/github-login** : 클라이언트에서 서버로 Github OAuth 인증을 요청 
- **GET /users/github-login/callback** : 클라이언트에서 서버로 Github OAuth 토큰 발행을 요청

### GitHub 로그인 성공시 처리
- GitHub 로그인에 성공한 경우 얻게되는 profile의 email 값으로 DB에서 user를 조회
- 해당 email에 일치하는 user 정보가 없다면 `account_type: 'github'`으로 새로운 레코드를 등록합니다
  - 등록 시 password는 github profile의 id 값을 임시로 저장 (추후에 딱히 사용되는 일은 없음)
- JWT를 생성하여 쿠키에 `authorization`으로 저장하고 메인 페이지로 redirect 
  - options - `httpOnly: true`

### JWT payload 내용
- userId : DB에서 자동으로 지정되는 record id 값
- email : user의 email 값(unique)

### auth 미들웨어
- `authorization` 토큰이 있는 경우 verify하여 payload의 email로 DB에서 user를 조회
- 조회된 user가 있는 경우 res.locals에 저장하여 이후 과정에서 사용할 수 있도록 함
- 토큰 검증에 실패한 경우 `401: Invalid or Expired Token Error` 에러 반환


## Note
- service 레이어 미구현
  - controller의 로직을 service 레이어로 분리하기 애매하여 일단 보류한 상태로 PR 날립니다. 
- user의 email 정보를 제공받기 위해 `passport-github2` 모듈을 사용했습니다.
- refresh token은 미구현 상태입니다.
