### PR TITLE
FE React Router 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1095,7 +1095,6 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
       "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -4763,6 +4762,19 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5731,6 +5743,15 @@
         "mime-db": "1.44.0"
       }
     },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -6667,7 +6688,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6844,6 +6864,52 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -6954,8 +7020,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -7152,6 +7217,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -8133,6 +8203,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -8489,6 +8569,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "core-js": "^3.6.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-router-dom": "^5.2.0",
     "styled-components": "^5.2.0"
   },
   "devDependencies": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,15 +1,16 @@
 import React from 'react';
+import { HashRouter as Router } from 'react-router-dom';
 // import Header from './components/Header';
 import GlobalStyle from './assets/styles/GlobalStyle';
-import LoginContainer from './containers/login/LoginContainer';
+import Routes from './routes';
 
 function App() {
   return (
-    <>
+    <Router>
       {/* <Header /> */}
       <GlobalStyle bg="#f6f8fa"/>
-      <LoginContainer />
-    </>
+      <Routes />
+    </Router>
   );
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import { HashRouter as Router } from 'react-router-dom';
 // import Header from './components/Header';
-import GlobalStyle from './assets/styles/GlobalStyle';
 import Routes from './routes';
 
 function App() {
   return (
     <Router>
       {/* <Header /> */}
-      <GlobalStyle bg="#f6f8fa"/>
       <Routes />
     </Router>
   );

--- a/frontend/src/constants/path.js
+++ b/frontend/src/constants/path.js
@@ -1,4 +1,5 @@
 const pathUri = {
+  home: '/',
   login: '/login',
 };
 

--- a/frontend/src/constants/path.js
+++ b/frontend/src/constants/path.js
@@ -1,6 +1,7 @@
 const pathUri = {
   home: '/',
   login: '/login',
+  issue: '/issues',
 };
 
 export default pathUri;

--- a/frontend/src/pages/Issue.js
+++ b/frontend/src/pages/Issue.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+const Issue = () => (
+  <>
+  </>
+);
+
+export default Issue;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import GlobalStyle from '../assets/styles/GlobalStyle';
+import LoginContainer from '../containers/login/LoginContainer';
+
+const Login = () => (
+  <>
+    <GlobalStyle bg="#f6f8fa"/>
+    <LoginContainer/>
+  </>
+);
+
+export default Login;

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -1,0 +1,2 @@
+export { default as Login } from './Login';
+export { default as Issue } from './Issue';

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+import pathUri from './constants/path';
+import { Login, Issue } from './pages';
+
+const routes = () => (
+  <Switch>
+    <Route exact path={pathUri.home} component={Login}/>
+    <Route path={pathUri.issue} component={Issue}/>
+  </Switch>
+);
+
+export default routes;


### PR DESCRIPTION
FE React Router 구현
## 개요
react router를 사용하여 사용자가 네비게이션 기능을 통해 페이지를 전환할 수 있도록 했다.
## 구현 내용 설명
src/routes.js : Route 컴포넌트 모아둔 곳 ( Route : path에 해당하는 component render하도록하는 컴포넌트)
(라우팅에 사용되는 path는 src/constants/path.js에 객체 형태로 정의)
src/pages/ : 각 페이지 화면에 해당하는 컴포넌트 정의 ( Route의 component 속성에 들아가는 컴포넌트), 
index에서 사용할 수 있도록 한꺼번에 export
src/app.js : 라우팅 기능을 사용하기 위해 Router 컴포넌트 추가 (HashRouter 사용)
## Notes
[React Router](https://github.com/boostcamp-2020/IssueTracker-22/wiki/React-Routing) 정리해둔 위키 문서 참고
HashRouter는 검색 엔진에서 읽을 수 없고 주소창에 '#'이 추가되어 BrowserRouter를 쓰는 것이 더 적절해보임.
그러나 BroswerRouter를 사용하기 위해서는 '/'이 아닌 다른 url에서 새로고침을 했을 때 서버에서 리액트 페이지를 반환하는 등의 처리가 필요함. 
