### PR TITLE
 #24 BE 마일스톤 목록 조회 API 구현

### DIFF
--- a/backend/__tests__/api/milestone.js
+++ b/backend/__tests__/api/milestone.js
@@ -17,4 +17,18 @@ describe('Milestone API', () => {
     expect(Array.isArray(body.content.milestones)).toBe(true);
     done();
   });
+
+  test('POST /milestones', async (done) => {
+    agent
+      .post('/milestones')
+      .send({ title: 'test', description: 'test', due_date: new Date() })
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        const { body } = res;
+        expect(body.success).toBe(true);
+        expect(body.content.id).not.toBeUndefined();
+        done();
+      });
+  });
 });

--- a/backend/__tests__/api/milestone.js
+++ b/backend/__tests__/api/milestone.js
@@ -1,0 +1,20 @@
+const request = require('supertest');
+const app = require('../../app');
+
+describe('Milestone API', () => {
+  let agent;
+
+  beforeAll(() => {
+    agent = request(app);
+  });
+
+  test('GET /milestones', async (done) => {
+    const res = await agent.get('/milestones');
+    const { body } = res;
+    expect(res.statusCode).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.content).toHaveProperty('milestones');
+    expect(Array.isArray(body.content.milestones)).toBe(true);
+    done();
+  });
+});

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -4,12 +4,12 @@ const router = express.Router();
 
 const userRouter = require('./users');
 const labelRouter = require('./labels');
-// const milestoneRouter = require('./milestones');
+const milestoneRouter = require('./milestones');
 const issueRouter = require('./issues');
 
 router.use('/users', userRouter);
 router.use('/labels', labelRouter);
-// router.use('/milestones', milestoneRouter);
+router.use('/milestones', milestoneRouter);
 router.use('/issues', issueRouter);
 
 module.exports = router;

--- a/backend/routes/labels/labels.controller.js
+++ b/backend/routes/labels/labels.controller.js
@@ -4,13 +4,13 @@ exports.list = async (req, res) => {
   try {
     const labels = await Label.findAll({
       attributes: ['id', 'name', 'description', 'color_code'],
-      where: { is_open: true },
     });
     return res.json({
       success: true,
       content: { labels },
     });
   } catch (err) {
+    console.log(err);
     res.status(500).json({ success: false, message: 'DB Error' });
   }
 };

--- a/backend/routes/labels/labels.controller.js
+++ b/backend/routes/labels/labels.controller.js
@@ -2,7 +2,10 @@ const { Label } = require('../../models');
 
 exports.list = async (req, res) => {
   try {
-    const labels = await Label.findAll();
+    const labels = await Label.findAll({
+      attributes: ['id', 'name', 'description', 'color_code'],
+      where: { is_open: true },
+    });
     return res.json({
       success: true,
       content: { labels },

--- a/backend/routes/milestones/index.js
+++ b/backend/routes/milestones/index.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const milestoneController = require('./milestones.controller');
+
+const router = express.Router();
+
+router.get('/', milestoneController.list);
+router.post('/', milestoneController.create);
+
+module.exports = router;

--- a/backend/routes/milestones/milestones.controller.js
+++ b/backend/routes/milestones/milestones.controller.js
@@ -1,0 +1,19 @@
+const { Milestone, Issue } = require('../../models');
+
+exports.list = async (req, res) => {
+  try {
+    const milestones = await Milestone.findAll({
+      attributes: ['id', 'title', 'description', 'due_date'],
+      include: [{
+        model: Issue,
+        attributes: ['id', 'is_open'],
+      }],
+    });
+    return res.json({
+      success: true,
+      content: { milestones },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, message: 'DB Error' });
+  }
+};

--- a/backend/routes/milestones/milestones.controller.js
+++ b/backend/routes/milestones/milestones.controller.js
@@ -17,3 +17,18 @@ exports.list = async (req, res) => {
     res.status(500).json({ success: false, message: 'DB Error' });
   }
 };
+
+exports.create = async (req, res) => {
+  const { title, description, due_date } = req.body;
+  try {
+    const newMilestones = await Milestone.create({
+      title, description, due_date,
+    });
+    return res.json({
+      success: true,
+      content: { id: newMilestones.id },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, message: 'DB Error' });
+  }
+};


### PR DESCRIPTION
### 구현 내용 
- 마일스톤 목록 조회 API 구현
- 마일스톤 생성 API 구현
- 테스트 코드 작성
### Notes
진행률을 계산한 상태로 주고 싶었으나 seqeulize에서 join, count 하는 방법 시도해보다가 못했습니다 .. 
프론트에서 계산하는 것이 더 빠를 것 같아 일단 조인한 상태로 응답하도록 했습니다. 

성공 응답 예시
```json
{
  "success": true,
  "content": {
    "milestones": [
      {
        "id": 1,
        "title": "week1",
        "description": "week1 milestone",
        "due_date": "2020-11-10T00:00:00.000Z",
        "issues": [
          {
            "id": 1,
            "is_open": 1
          }
        ]
      },
      {
        "id": 2,
        "title": "week2",
        "description": "week2",
        "due_date": "2020-12-25T00:00:00.000Z",
        "issues": []
      }
    ]
  }
}
```