### PR TITLE
#31 BE 새로운 이슈 추가 API 구현 

### DIFF
--- a/backend/routes/issues/index.js
+++ b/backend/routes/issues/index.js
@@ -1,7 +1,10 @@
 const express = require('express');
+const { authMiddleware } = require('../../middlewares/auth');
 const issuesController = require('./issues.controller');
+
 const issue = express.Router();
 
 issue.get('/', issuesController.list);
+issue.post('/', authMiddleware, issuesController.create);
 
 module.exports = issue;

--- a/backend/routes/issues/issues.controller.js
+++ b/backend/routes/issues/issues.controller.js
@@ -81,19 +81,25 @@ exports.list = async (req, res) => {
   }
 };
 
-// 이슈 제목, 내용, 담당자, 레이블, 마일스톤 정보를 받아 DB에 새로운 이슈를 추가하는 API 구현
 exports.create = async (req, res) => {
   const {
     title, description, assignee_id, label_id, milestone_id,
   } = req.body;
   const { user } = res.locals;
   try {
-    const newIssues = await Issue.create({
-      title, description, author_id: user.id, assignee_id, label_id, milestone_id,
-    });
-    await IssueAssignee.create({
-      issue_id: newIssues.id, assignee_id,
-    });
+    let newIssues;
+    if (assignee_id) {
+      newIssues = await Issue.create({
+        title, description, author_id: user.id, assignee_id, label_id, milestone_id,
+      });
+      await IssueAssignee.create({
+        issue_id: newIssues.id, assignee_id,
+      });
+    } else {
+      newIssues = await Issue.create({
+        title, description, author_id: user.id, label_id, milestone_id,
+      });
+    }
     return res.json({
       success: true,
       content: { id: newIssues.id },

--- a/backend/routes/issues/issues.controller.js
+++ b/backend/routes/issues/issues.controller.js
@@ -1,28 +1,29 @@
 const {
-  Issue, 
-  User, 
-  IssueLabel, 
-  Label, 
-  IssueAssignee, 
-  Milestone, 
-  Comment} = require('../../models');
+  Issue,
+  User,
+  IssueLabel,
+  Label,
+  IssueAssignee,
+  Milestone,
+  Comment,
+} = require('../../models');
 
 exports.list = async (req, res) => {
-  const { 
-    user, 
-    label, 
-    milestone, 
-    isopen, 
-    assignee, 
-    mention 
+  const {
+    user,
+    label,
+    milestone,
+    isopen,
+    assignee,
+    mention,
   } = req.query;
-  const filterUser = (user === undefined) ? {} : {nickname: user};
-  const filterLabel = (label === undefined) ? {} : {name: label};
-  const filterMilestone = (milestone === undefined) ? {} : {title: milestone};
-  const filterIsopen = (isopen === undefined) ? {} : {is_open: isopen};
-  const filterAssignee = (assignee === undefined) ? {} : {nickname: assignee};
-  const filterMention = (mention === undefined) ? {} : {author_id: mention};
-  console.log(isopen);
+  const filterUser = (user === undefined) ? {} : { nickname: user };
+  const filterLabel = (label === undefined) ? {} : { name: label };
+  const filterMilestone = (milestone === undefined) ? {} : { title: milestone };
+  const filterIsopen = (isopen === undefined) ? {} : { is_open: isopen };
+  const filterAssignee = (assignee === undefined) ? {} : { nickname: assignee };
+  const filterMention = (mention === undefined) ? {} : { author_id: mention };
+
   try {
     const issues = await Issue.findAll({
       attributes: ['id', 'title', 'description', 'createdAt', 'updatedAt'],
@@ -31,7 +32,7 @@ exports.list = async (req, res) => {
         {
           model: User,
           attributes: ['id', 'nickname'],
-          where: filterUser
+          where: filterUser,
         },
         {
           model: IssueLabel,
@@ -40,8 +41,8 @@ exports.list = async (req, res) => {
             {
               model: Label,
               where: filterLabel,
-              attributes: ['id', 'name', 'color_code']
-            }
+              attributes: ['id', 'name', 'color_code'],
+            },
           ],
         },
         {
@@ -51,15 +52,15 @@ exports.list = async (req, res) => {
             {
               model: User,
               attributes: ['profile_url'],
-              where: filterAssignee
-            }
-          ]
+              where: filterAssignee,
+            },
+          ],
         },
         {
           model: Milestone,
           attributes: ['id', 'title'],
           where: filterMilestone,
-          required: false
+          required: false,
         },
         {
           model: Comment,
@@ -68,14 +69,36 @@ exports.list = async (req, res) => {
             {
               model: User,
               where: filterMention,
-              attributes: ['id']
-            }
+              attributes: ['id'],
+            },
           ],
-        }
-      ]
+        },
+      ],
     });
     res.json({ success: true, content: { issues } });
   } catch (err) {
-    res.status(400).json({ success: false, message: "Fail: Get Issue-List" });
+    res.status(400).json({ success: false, message: 'Fail: Get Issue-List' });
+  }
+};
+
+// 이슈 제목, 내용, 담당자, 레이블, 마일스톤 정보를 받아 DB에 새로운 이슈를 추가하는 API 구현
+exports.create = async (req, res) => {
+  const {
+    title, description, assignee_id, label_id, milestone_id,
+  } = req.body;
+  const { user } = res.locals;
+  try {
+    const newIssues = await Issue.create({
+      title, description, author_id: user.id, assignee_id, label_id, milestone_id,
+    });
+    await IssueAssignee.create({
+      issue_id: newIssues.id, assignee_id,
+    });
+    return res.json({
+      success: true,
+      content: { id: newIssues.id },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, message: 'Internel Server Error' });
   }
 };

--- a/backend/routes/issues/issues.controller.js
+++ b/backend/routes/issues/issues.controller.js
@@ -86,20 +86,22 @@ exports.create = async (req, res) => {
     title, description, assignee_id, label_id, milestone_id,
   } = req.body;
   const { user } = res.locals;
+
   try {
-    let newIssues;
+    const newIssues = await Issue.create({
+      title, description, author_id: user.id, assignee_id, label_id, milestone_id,
+    });
     if (assignee_id) {
-      newIssues = await Issue.create({
-        title, description, author_id: user.id, assignee_id, label_id, milestone_id,
-      });
       await IssueAssignee.create({
         issue_id: newIssues.id, assignee_id,
       });
-    } else {
-      newIssues = await Issue.create({
-        title, description, author_id: user.id, label_id, milestone_id,
+    }
+    if (label_id) {
+      await IssueLabel.create({
+        issue_id: newIssues.id, label_id,
       });
     }
+
     return res.json({
       success: true,
       content: { id: newIssues.id },

--- a/backend/routes/users/users.controller.js
+++ b/backend/routes/users/users.controller.js
@@ -2,10 +2,15 @@ const passport = require('passport');
 const jwt = require('jsonwebtoken');
 const { User } = require('../../models');
 
-exports.getAllUsers = async (req, res, next) => {
+exports.getAllUsers = async (req, res) => {
   try {
-    const users = await User.findAll();
-    res.json(users);
+    const users = await User.findAll({
+      attributes: ['id', 'nickname', 'profile_url'],
+    });
+    res.json({
+      success: true,
+      content: { users },
+    });
   } catch (err) {
     res.status(500).json({ success: false, message: 'Error' });
   }


### PR DESCRIPTION
### 구현 내용
- 이슈 제목, 내용, 담당자, 레이블, 마일스톤 정보를 받아 DB에 새로운 이슈를 추가하는 API 구현
- assignee_id 있는 경우 IssueAssignee 테이블에 관계 추가 
- user 조회 API 수정 (지정가능한 담당자 목록 조회 API로 활용 가능)

### Notes
새로운 이슈 추가 라우터에 authMiddleware 사용하여 로그인된 사용자만 이슈 추가할 수 있도록 했음.
다른 조회 API에도 auth 체크해야하는지 논의해봐야할 듯함 ..