### PR TITLE
#17 [BE]  이슈 상세정보 API 구현

### DIFF
--- a/backend/__tests__/api/issue.detail.js
+++ b/backend/__tests__/api/issue.detail.js
@@ -1,0 +1,26 @@
+const request = require('supertest');
+const app = require('../../app');
+
+describe('Label API', () => {
+  let agent;
+
+  beforeAll(() => {
+    agent = request(app);
+  });
+
+  test('GET /issues/:issue-number', async (done) => {
+    const issueNumber = 1;
+    const res = await agent.get(`/issue/${issueNumber}`);
+    const { body } = res;
+    expect(res.statusCode).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.content).toHaveProperty('labels');
+    expect(body.content).toHaveProperty('milestone');
+    expect(body.content).toHaveProperty('assignees');
+    expect(body.content).toHaveProperty('isOpen');
+    expect(body.content.isOpen).toBe(true);
+    expect(body.content).toHaveProperty('comments');
+    expect(Array.isArray(body.content.comments)).toBe(true);
+    done();
+  });
+});

--- a/backend/routes/issues/index.js
+++ b/backend/routes/issues/index.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const issuesController = require('./issues.controller');
+
 const issue = express.Router();
 
 issue.get('/', issuesController.list);
-issue.get('/:issueNumber', issuesController.detail)
+issue.get('/:issueNumber', issuesController.detail);
 
 module.exports = issue;

--- a/backend/routes/issues/index.js
+++ b/backend/routes/issues/index.js
@@ -3,5 +3,6 @@ const issuesController = require('./issues.controller');
 const issue = express.Router();
 
 issue.get('/', issuesController.list);
+issue.get('/:issueNumber', issuesController.detail)
 
 module.exports = issue;

--- a/backend/routes/issues/issues.controller.js
+++ b/backend/routes/issues/issues.controller.js
@@ -6,6 +6,7 @@ const {
   IssueAssignee, 
   Milestone, 
   Comment} = require('../../models');
+const milestone = require('../../models/milestone');
 
 exports.list = async (req, res) => {
   const { 
@@ -79,3 +80,47 @@ exports.list = async (req, res) => {
     res.status(400).json({ success: false, message: "Fail: Get Issue-List" });
   }
 };
+
+exports.detail = async (req, res) => {
+  const { issueNumber } = req.params
+  const hasIssueNumber = {id : issueNumber}
+  try {
+    let issues = await Issue.findAll({
+      attributes: ['id', 'title', 'description', 'createdAt', 'updatedAt'],
+      where: hasIssueNumber,
+      include:[{
+        model: User,
+        attributes: ['id', 'nickname', 'profile_url'],
+      },{
+        model: Comment,
+        attributes: ['id', 'description', 'author_id'],
+        include:[{
+          model: User,
+          attributes: ['id', 'nickname', 'profile_url'],
+        }]
+      },{
+        model: Milestone,
+        attributes: ['id', 'title'],
+      },{
+        model: IssueLabel,
+        include:[{
+          model: Label,
+          attributes: ['id', 'name', 'color_code']
+        }]
+      },{
+        model: IssueAssignee,
+        include:[{
+          model: User,
+          attributes: ['id', 'nickname', 'profile_url'],
+        }]
+      }
+      
+    ]
+      
+    })
+    
+    res.json({ success: true, content: { issues } })
+  } catch(err) {
+    res.status(400).json({ success: false, message: "Fail: Get Issue Detail" })
+  }
+}

--- a/backend/routes/issues/issues.controller.js
+++ b/backend/routes/issues/issues.controller.js
@@ -121,6 +121,6 @@ exports.detail = async (req, res) => {
     
     res.json({ success: true, content: { issues } })
   } catch(err) {
-    res.status(400).json({ success: false, message: "Fail: Get Issue Detail" })
+    res.status(500).json({ success: false, message: "Fail: Get Issue Detail" })
   }
 }

--- a/backend/routes/issues/issues.controller.js
+++ b/backend/routes/issues/issues.controller.js
@@ -1,28 +1,29 @@
 const {
-  Issue, 
-  User, 
-  IssueLabel, 
-  Label, 
-  IssueAssignee, 
-  Milestone, 
-  Comment} = require('../../models');
+  Issue,
+  User,
+  IssueLabel,
+  Label,
+  IssueAssignee,
+  Milestone,
+  Comment,
+} = require('../../models');
 const milestone = require('../../models/milestone');
 
 exports.list = async (req, res) => {
-  const { 
-    user, 
-    label, 
-    milestone, 
-    isopen, 
-    assignee, 
-    mention 
+  const {
+    user,
+    label,
+    milestone,
+    isopen,
+    assignee,
+    mention,
   } = req.query;
-  const filterUser = (user === undefined) ? {} : {nickname: user};
-  const filterLabel = (label === undefined) ? {} : {name: label};
-  const filterMilestone = (milestone === undefined) ? {} : {title: milestone};
-  const filterIsopen = (isopen === undefined) ? {} : {is_open: isopen};
-  const filterAssignee = (assignee === undefined) ? {} : {nickname: assignee};
-  const filterMention = (mention === undefined) ? {} : {author_id: mention};
+  const filterUser = (user === undefined) ? {} : { nickname: user };
+  const filterLabel = (label === undefined) ? {} : { name: label };
+  const filterMilestone = (milestone === undefined) ? {} : { title: milestone };
+  const filterIsopen = (isopen === undefined) ? {} : { is_open: isopen };
+  const filterAssignee = (assignee === undefined) ? {} : { nickname: assignee };
+  const filterMention = (mention === undefined) ? {} : { author_id: mention };
   console.log(isopen);
   try {
     const issues = await Issue.findAll({
@@ -32,7 +33,7 @@ exports.list = async (req, res) => {
         {
           model: User,
           attributes: ['id', 'nickname'],
-          where: filterUser
+          where: filterUser,
         },
         {
           model: IssueLabel,
@@ -41,8 +42,8 @@ exports.list = async (req, res) => {
             {
               model: Label,
               where: filterLabel,
-              attributes: ['id', 'name', 'color_code']
-            }
+              attributes: ['id', 'name', 'color_code'],
+            },
           ],
         },
         {
@@ -52,15 +53,15 @@ exports.list = async (req, res) => {
             {
               model: User,
               attributes: ['profile_url'],
-              where: filterAssignee
-            }
-          ]
+              where: filterAssignee,
+            },
+          ],
         },
         {
           model: Milestone,
           attributes: ['id', 'title'],
           where: filterMilestone,
-          required: false
+          required: false,
         },
         {
           model: Comment,
@@ -69,58 +70,60 @@ exports.list = async (req, res) => {
             {
               model: User,
               where: filterMention,
-              attributes: ['id']
-            }
+              attributes: ['id'],
+            },
           ],
-        }
-      ]
+        },
+      ],
     });
     res.json({ success: true, content: { issues } });
   } catch (err) {
-    res.status(400).json({ success: false, message: "Fail: Get Issue-List" });
+    res.status(400).json({ success: false, message: 'Fail: Get Issue-List' });
   }
 };
 
 exports.detail = async (req, res) => {
-  const { issueNumber } = req.params
-  const hasIssueNumber = {id : issueNumber}
+  const { issueNumber } = req.params;
+  const hasIssueNumber = { id: issueNumber };
   try {
-    let issues = await Issue.findAll({
+    const issues = await Issue.findAll({
       attributes: ['id', 'title', 'description', 'createdAt', 'updatedAt'],
       where: hasIssueNumber,
-      include:[{
+      include: [{
         model: User,
         attributes: ['id', 'nickname', 'profile_url'],
-      },{
+      }, {
         model: Comment,
         attributes: ['id', 'description', 'author_id'],
-        include:[{
+        include: [{
           model: User,
           attributes: ['id', 'nickname', 'profile_url'],
-        }]
-      },{
+        }],
+      }, {
         model: Milestone,
         attributes: ['id', 'title'],
-      },{
+      }, {
         model: IssueLabel,
-        include:[{
+        attributes: ['id'],
+        include: [{
           model: Label,
-          attributes: ['id', 'name', 'color_code']
-        }]
-      },{
+          attributes: ['id', 'name', 'color_code'],
+        }],
+      }, {
         model: IssueAssignee,
-        include:[{
+        attributes: ['id'],
+        include: [{
           model: User,
           attributes: ['id', 'nickname', 'profile_url'],
-        }]
-      }
-      
-    ]
-      
-    })
-    
-    res.json({ success: true, content: { issues } })
-  } catch(err) {
-    res.status(500).json({ success: false, message: "Fail: Get Issue Detail" })
+        }],
+      },
+
+      ],
+
+    });
+
+    res.json({ success: true, content: { issues } });
+  } catch (err) {
+    res.status(500).json({ success: false, message: 'Fail: Get Issue Detail' });
   }
-}
+};


### PR DESCRIPTION
## 개요
- 이슈 상세내용에서 사용되는 정보들을 가져다주는 API 구현

## 구현 내용
![image](https://user-images.githubusercontent.com/48170519/98208862-5f987000-1f81-11eb-93aa-90ccaa8081fc.png)

- 포함 내용 : 이슈 관련 정보, 코멘트 관련정보, 마일스톤, 라벨, 담당자
- API 호출 방법 : `/issues/:issueNumber`


