### PR TITLE
#12 [FE] 이슈 목록 상단에 각 화면으로 이동하는 이슈 생성, 레이블, 마일스톤 버튼 구현

### DIFF
--- a/frontend/src/assets/styles/caret.js
+++ b/frontend/src/assets/styles/caret.js
@@ -1,0 +1,15 @@
+const dropdownCaret = {
+    marginLeft : "3px",
+    display: "inline-block",
+    width: "0",
+    height: "0",
+    verticalAlign: "middle",
+    content: "",
+    borderTopStyle: "solid",
+    borderTopWidth: "4px",
+    borderRight: "4px solid transparent",
+    borderBottom: "0 solid transparent",
+    borderLeft: "4px solid transparent",
+}
+
+export default  dropdownCaret

--- a/frontend/src/assets/svgPath.js
+++ b/frontend/src/assets/svgPath.js
@@ -4,5 +4,5 @@ const svgMilestone = (<path fill-rule="evenodd" d="M7.75 0a.75.75 0 01.75.75V3h3
 const svgOpen = (<path fill-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9 3a1 1 0 11-2 0 1 1 0 012 0zm-.25-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"></path>)
 const svgClose = (<path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 0110.65-5.003.75.75 0 00.959-1.153 8 8 0 102.592 8.33.75.75 0 10-1.444-.407A6.5 6.5 0 011.5 8zM8 12a1 1 0 100-2 1 1 0 000 2zm0-8a.75.75 0 01.75.75v3.5a.75.75 0 11-1.5 0v-3.5A.75.75 0 018 4zm4.78 4.28l3-3a.75.75 0 00-1.06-1.06l-2.47 2.47-.97-.97a.749.749 0 10-1.06 1.06l1.5 1.5a.75.75 0 001.06 0z"></path>)
 const svgCheck = (<path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>)
-
-export { svgMilestone, svgOpen, svgClose, svgCheck }
+const svgX = <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
+export { svgMilestone, svgOpen, svgClose, svgCheck, svgX }

--- a/frontend/src/containers/issue/components/searchFilter.js
+++ b/frontend/src/containers/issue/components/searchFilter.js
@@ -1,0 +1,87 @@
+import styled from 'styled-components';
+import React, { Component } from 'react';
+import dropdownCaret from '../../../assets/styles/caret'
+import {svgX} from '../../../assets/svgPath'
+
+const SearchFilter = styled.div`
+    position: relative;
+    summary::-webkit-details-marker {
+        display: none
+    }
+`;
+
+const FilterItemList = styled.div`
+    width: 300px;
+    height: auto;
+    max-height: 480px;
+    margin: 8px 0 16px;
+    font-size: 12px;
+    border-color: #eaecef;
+    border-radius: 6px;
+    box-shadow: #eaecef;
+`;
+
+const FilterItem = styled.div`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 16px;
+    overflow: hidden;
+    color: black;
+    text-align: left;
+    cursor: pointer;
+    border: 0;
+    border-bottom: 1px solid #eaecef;
+`;
+
+const FilterModal = {
+        display: "none",
+        width: "500px",
+        height: "500px",
+        position: "absolute",
+        top:"50%",
+        left: "50%",
+        margin: "-250px 0 0 -250px",
+        background: "#eaecef",
+        zIndex: "2",
+}
+
+const renderSearchFilter = () =>{
+    const items = ["Open issues and pull requests", "Your issues", "Your pull issues", "Everything assinged to you", "Everything mentioning you"]
+    const filterItems = () => {
+        return items.map((item) => {
+            return (<FilterItem>{item}</FilterItem>)
+        })
+    }
+
+    const onModal = () => {
+        // document.querySelector('.filter-modal').style.display ='block';
+    }
+
+    const offModal = () => {
+        // document.querySelector('.filter-modal').style.display ='none';
+    }
+    return (
+        <SearchFilter>
+            <details class="IssueFilter">
+                <summary role="button" onClick={onModal()}>
+                    Filters
+                    <span style={dropdownCaret}/>
+                </summary>
+                <div class=".filter-modal" style={FilterModal}>
+                    <FilterItemList>
+                        <h3>Filter Issues</h3>
+                        <button type="button" data-toggle-for="IssueFilter" onClick={offModal()}>
+                            <svg aria-label="Close menu" class="octicon octicon-x" viewBox="0 0 16 16" version="1.1" width="16" height="16" role="img">
+                                {svgX}                            
+                            </svg>
+                        </button>
+                        {filterItems()}
+                    </FilterItemList>
+                </div>
+            </details>
+        </SearchFilter>
+    )
+}
+
+export default renderSearchFilter;

--- a/frontend/src/containers/issue/components/searchFilter.js
+++ b/frontend/src/containers/issue/components/searchFilter.js
@@ -35,7 +35,7 @@ const FilterItem = styled.div`
 `;
 
 const FilterModal = {
-        display: "none",
+        // display: "none",
         width: "500px",
         height: "500px",
         position: "absolute",
@@ -68,7 +68,7 @@ const renderSearchFilter = () =>{
                     Filters
                     <span style={dropdownCaret}/>
                 </summary>
-                <div class=".filter-modal" style={FilterModal}>
+                {/* <div class=".filter-modal" style={FilterModal}> */}
                     <FilterItemList>
                         <h3>Filter Issues</h3>
                         <button type="button" data-toggle-for="IssueFilter" onClick={offModal()}>
@@ -78,7 +78,7 @@ const renderSearchFilter = () =>{
                         </button>
                         {filterItems()}
                     </FilterItemList>
-                </div>
+                {/* </div> */}
             </details>
         </SearchFilter>
     )

--- a/frontend/src/containers/issue/components/toolButtons.js
+++ b/frontend/src/containers/issue/components/toolButtons.js
@@ -1,13 +1,20 @@
 import styled from 'styled-components';
 import React, { Component } from 'react';
+import renderSearchFilter from './searchFilter'
 
+const ToolButtons = styled.div`
+    display: flex;
+    flex-direction: row;
+`;
 
 const renderToolButtons = () => {
+    console.log("done?")
     return (
         <ToolButtons>
-            <SearchBar/>
-            <LabelandMilestone/>
-            <NewIssueButton/>
+            {renderSearchFilter()}
+            {/* <SearchBar/> */}
+            {/* <LabelMilestone/> */}
+            {/* <NewIssueButton/> */}
         </ToolButtons>
     )
 

--- a/frontend/src/containers/issue/components/toolButtons.js
+++ b/frontend/src/containers/issue/components/toolButtons.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+import React, { Component } from 'react';
+
+
+const renderToolButtons = () => {
+    return (
+        <ToolButtons>
+            <SearchBar/>
+            <LabelandMilestone/>
+            <NewIssueButton/>
+        </ToolButtons>
+    )
+
+}
+
+export default renderToolButtons;

--- a/frontend/src/containers/issue/issueContainer.js
+++ b/frontend/src/containers/issue/issueContainer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import IssueToolbar from './components/issueToolbar'
 import IssueList from './components/issueList'
+import renderToolButtons from './components/toolButtons'
 import styled from 'styled-components';
 
 const IssueContainer = styled.div`
@@ -83,7 +84,7 @@ class Issue extends Component {
         // const data = getIssues()
         return (
             <IssueContainer>
-                <ToolButtons/>
+                {renderToolButtons()}
                 <IssueToolbar data={dummy}/>
                 <IssueList data={dummy}/>
             </IssueContainer>

--- a/frontend/src/containers/issue/issueContainer.js
+++ b/frontend/src/containers/issue/issueContainer.js
@@ -83,6 +83,7 @@ class Issue extends Component {
         // const data = getIssues()
         return (
             <IssueContainer>
+                <ToolButtons/>
                 <IssueToolbar data={dummy}/>
                 <IssueList data={dummy}/>
             </IssueContainer>

--- a/frontend/src/pages/Issue.js
+++ b/frontend/src/pages/Issue.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import IssueContainer from '../containers/issue/issueContainer'
 
 const Issue = () => (
-  <>
-  </>
+  <IssueContainer/>
 );
 
 export default Issue;


### PR DESCRIPTION
## 개요
- 이슈 리스트위의 필터리스트, 검색창, 라벨및 마일스톤 버늩, 새로운 이슈작성 버튼 구현
- 이중 필터리스트 구현중(아직 12번 이슈 닫지말기!)

## 구현 내용
![image](https://user-images.githubusercontent.com/48170519/98224492-de4bd800-1f96-11eb-9a20-44c132323716.png)

- 아직 스타일이 확실히 정리되지 못함
- 필터리스트를 모달로 개발중인데 모달 On/Off과정에서 어려움이 있음