### PR TITLE
#13 이슈 작성 form UI 구현

### DIFF
--- a/frontend/src/constants/api.js
+++ b/frontend/src/constants/api.js
@@ -1,5 +1,6 @@
 const apiUri = {
   login: '/users/github-login',
+  issues: '/issues',
 };
 
 export default apiUri;

--- a/frontend/src/constants/path.js
+++ b/frontend/src/constants/path.js
@@ -1,7 +1,7 @@
 const pathUri = {
   home: '/',
-  login: '/login',
   issue: '/issues',
+  createIssue: '/issues/new',
 };
 
 export default pathUri;

--- a/frontend/src/containers/issue-form/IssueFormContainer.js
+++ b/frontend/src/containers/issue-form/IssueFormContainer.js
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import apiUri from '../../constants/api';
+import CommentEditor from './components/CommentEditor';
+import SubmitButton from './components/SubmitButton';
+import CancelButton from './components/CancelButton';
+import UserProfileContainer from '../user-profile/UserProfileContainer';
+
+const IssueFormBox = styled.div`
+  border: 1px solid lightgray;
+  border-radius: 5px;
+  padding: 10px;
+  background-color: white;
+  flex: 1 1 0;
+`;
+
+const Input = styled.input`
+  display: block;
+  width: 100%;
+  padding: 7px 10px;
+  background-color: #FAFAFA;
+  border: 1px solid lightgray;
+  border-radius: 5px;
+  font-size: 18px;
+  :focus {
+    background-color: white;
+    border-color: blue;
+    outline: none;
+    box-shadow: 0 0 0 3px #B9D9E8;
+  }
+`;
+
+const FlexRowBetween = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  flex-wrap: wrap;
+`;
+
+const CommentFormWrapper = styled.div`
+  flex: 3 3 0;
+  min-width: 500px;
+  display: flex;
+  padding: 0 10px;
+`;
+
+const IssueOptionalFormWrapper = styled.div`
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  min-width: 200px;
+  padding: 0 10px;
+  border: 1px solid red;
+`;
+
+const IssueForm = () => {
+  const [issue, setIssue] = useState({ title: '', description: '' });
+
+  const submitHandler = (e) => {
+    e.preventDefault();
+
+    // TODO 1 : validation 체크 후 -> POST apiUri.issues fetch 요청
+    alert(`Handle Submit => POST ${apiUri.issues} :: ${JSON.stringify(issue)}`);
+    // TODO 2 : submit 완료 후 issue 상세 화면으로 이동
+  };
+
+  const setIssueTitle = (e) => {
+    // setIssue(Object.assign(issue, { title: e.target.value }));
+    setIssue({ ...issue, title: e.target.value });
+  };
+
+  const setIssueDesc = (e) => {
+    setIssue({ ...issue, description: e.target.value });
+  };
+
+  const uploadFile = (e) => {
+    const { files } = e.target;
+    console.log(files);
+    // TODO : 파일 업로드 구현
+  };
+
+  return (
+    <div style={{ padding: '0 3%', backgroundColor: 'white' }}>
+      <form onSubmit={submitHandler}>
+
+        <FlexRowBetween>
+
+          <CommentFormWrapper>
+            <UserProfileContainer/>
+
+            <IssueFormBox>
+              <Input type="text" placeholder="Title" onChange={setIssueTitle} />
+
+              <CommentEditor onChange={setIssueDesc} onFileUpload={uploadFile} />
+
+              <FlexRowBetween>
+                <CancelButton path="/#/issues" />
+                <SubmitButton onClick={submitHandler} target={issue} />
+              </FlexRowBetween>
+            </IssueFormBox>
+          </CommentFormWrapper>
+
+          <IssueOptionalFormWrapper>
+
+            <div>Assignees</div>
+            <div>Labels</div>
+            <div>Milestone</div>
+
+          </IssueOptionalFormWrapper>
+
+        </FlexRowBetween>
+      </form>
+    </div>
+  );
+};
+
+export default IssueForm;

--- a/frontend/src/containers/issue-form/components/CancelButton.js
+++ b/frontend/src/containers/issue-form/components/CancelButton.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Button = styled.button`
+  all: unset;
+  display: block;
+  font-size: 15px;
+  border: none;
+  padding: 8px 15px;
+`;
+
+const CancelButton = ({ path }) => {
+  const onClick = () => {
+    window.location.href = path; // '/#/issues';
+  };
+  return <Button type="reset" value="Cancel" onClick={onClick}>Cancel</Button>;
+};
+
+export default CancelButton;

--- a/frontend/src/containers/issue-form/components/CommentEditor.js
+++ b/frontend/src/containers/issue-form/components/CommentEditor.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const CommentEditorWrapper = styled.div`
+  width: 100%;
+  background-color: white;
+  position: relative;
+  margin: 10px 0;
+`;
+
+const Tabs = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  border-bottom: 1px solid lightgray;
+  margin: 10px 0;
+`;
+
+const Tab = styled.button`
+  all: unset;
+  color: gray;
+  border: 1px solid lightgray;
+  border-bottom: none;
+  padding: 10px 15px;
+  margin-right: 7px;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  transition: all 0.5s;
+  :hover {
+    transition: all 0.5s;
+    color: black;
+  }
+`;
+
+const Textarea = styled.textarea`
+  padding: 10px;
+  width: 100%;
+  height: 200px;
+  border: none;
+  border-bottom: 1px dashed lightgray;
+  background-color: inherit;
+  font-size: 18px;
+  resize: vertical;
+  :focus {
+    background-color: white;
+    border-color: blue;
+    outline: none;
+    box-shadow: 0 0 0 3px #B9D9E8;
+  }
+`;
+
+const FileChooserBox = styled.div`
+  position: relative;
+`;
+
+const FileChooser = styled.input`
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  opacity: .01;
+`;
+
+const FileChooserLabel = styled.div`
+  padding: 5px 10px;
+  width: 100%;
+  background-color: #FAFAFA;
+  pointer-events: none;
+`;
+
+const WriteBox = styled.div`
+  width: 100%;
+  overflow: hidden;
+  background-color: #FAFAFA;
+  border: 1px solid lightgray;
+  border-radius: 5px;
+`;
+
+// eslint-disable-next-line arrow-body-style
+const CommentEditor = ({ onChange, onFileUpload }) => {
+  return (
+    <CommentEditorWrapper>
+      <Tabs>
+        <Tab type="button">Write</Tab>
+        <Tab type="button">Preview</Tab>
+      </Tabs>
+
+      <WriteBox>
+        <Textarea placeholder="Leave a comment" onChange={onChange} />
+        <FileChooserBox>
+          <FileChooser accept=".gif,.jpeg,.jpg,.png,.docx,.gz,.log,.pdf,.pptx,.txt,.xlsx,.zip" type="file" multiple="" onChange={onFileUpload} />
+          <FileChooserLabel>Attach files by selecting here</FileChooserLabel>
+        </FileChooserBox>
+      </WriteBox>
+    </CommentEditorWrapper>
+  );
+};
+
+export default CommentEditor;

--- a/frontend/src/containers/issue-form/components/SubmitButton.js
+++ b/frontend/src/containers/issue-form/components/SubmitButton.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Button = styled.button`
+  display: block;
+  color: white;
+  font-size: 15px;
+  background-color: #0DBF18;
+  border: 1px solid #009B09;
+  border-radius: 5px;
+  padding: 8px 15px;
+  :disabled {
+    background-color: #89C990;
+  }
+`;
+
+// eslint-disable-next-line arrow-body-style
+const SubmitButton = ({ onClick, target }) => {
+  return <Button type="submit" value="Submit" onClick={onClick} disabled={target.title === '' || target.description === ''}>Submit new Issue</Button>;
+};
+
+export default SubmitButton;

--- a/frontend/src/containers/user-profile/UserProfileContainer.js
+++ b/frontend/src/containers/user-profile/UserProfileContainer.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+// import apiUri from '../../constants/api';
+
+const ProfileImage = styled.img`
+  width: 40px;
+  height: 40px;
+  border-radius: 50px;
+  margin-right: 15px;
+`;
+
+// TODO: user data를 받아 src 및 alt 설정
+// eslint-disable-next-line arrow-body-style
+const UserProfileContainer = () => {
+  return (
+    <>
+      <a href="/#/">
+        <ProfileImage src="https://avatars1.githubusercontent.com/u/57661699?s=80&amp;v=4" alt="@caribouuuu" />
+      </a>
+    </>
+  );
+};
+
+export default UserProfileContainer;

--- a/frontend/src/pages/CreateIssue.js
+++ b/frontend/src/pages/CreateIssue.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import GlobalStyle from '../assets/styles/GlobalStyle';
 import Header from '../components/Header';
-import IssueForm from '../containers/issue-form/IssueForm';
+import IssueFormContainer from '../containers/issue-form/IssueFormContainer';
 
 const CreateIssue = () => (
   <>
     <GlobalStyle bg="#f6f8fa"/>
     <Header/>
-    <IssueForm/>
+    <IssueFormContainer/>
   </>
 );
 

--- a/frontend/src/pages/CreateIssue.js
+++ b/frontend/src/pages/CreateIssue.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import GlobalStyle from '../assets/styles/GlobalStyle';
+import Header from '../components/Header';
+import IssueForm from '../containers/issue-form/IssueForm';
+
+const CreateIssue = () => (
+  <>
+    <GlobalStyle bg="#f6f8fa"/>
+    <Header/>
+    <IssueForm/>
+  </>
+);
+
+export default CreateIssue;

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -1,2 +1,3 @@
 export { default as Login } from './Login';
 export { default as Issue } from './Issue';
+export { default as CreateIssue } from './CreateIssue';

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import pathUri from './constants/path';
-import { Login, Issue } from './pages';
+import { Login, Issue, CreateIssue } from './pages';
 
 const routes = () => (
   <Switch>
     <Route exact path={pathUri.home} component={Login}/>
+    <Route exact path={pathUri.createIssue} component={CreateIssue}/>
     <Route path={pathUri.issue} component={Issue}/>
   </Switch>
 );

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = {
     port: 8081,
     hot: true,
     proxy: {
-      '/api': 'http://127.0.0.1:3000',
+      '/': 'http://127.0.0.1:3000',
     },
   },
 


### PR DESCRIPTION
## 개요
이슈 작성 form UI 구현

<img width="1280" alt="스크린샷 2020-11-05 오후 6 54 40" src="https://user-images.githubusercontent.com/57661699/98225720-6c748e00-1f98-11eb-9870-629378ee83e9.png">


## 구현 내용 설명
- src/pages/CreateIssue.js : Header와 IssueFormContainer를 사용하는 이슈 작성 페이지 등록
- Route에 이슈 작성 페이지 path 등록 (`/issues/new`)
- IssueFormContainer.js : 새로운 issue 작성을 위한 form UI 
  - CommentEditor.js 사용 -> Comment 작성/수정시 재사용할 수 있는 컴포넌트
  - Cancel, Submit 버튼 사용
- Submit 버튼 이벤트 등록 : issue form의 title, description 값이 입력되어야 활성화되도록 구현

## Note
- 컴포넌트 명 및 UI 구조 개선 필요
### Todo (현재 미구현 내용)
- 파일 업로드 시 처리 구현
- Side의 Assignees, Labels, Milestone 등록 컴포넌트 구현 완료시 Issue form UI 에 추가

