### PR TITLE
FE 로그인 성공 시 user 정보 userContext로 저장

### DIFF
--- a/backend/routes/users/index.js
+++ b/backend/routes/users/index.js
@@ -4,6 +4,7 @@ const { authMiddleware } = require('../../middlewares/auth');
 
 const router = express.Router();
 
+router.get('/me', authMiddleware, userController.getLoggedInUser);
 router.get('/', authMiddleware, userController.getAllUsers);
 router.get('/github-login', userController.githubLogin);
 router.get('/github-login/callback', userController.githubLoginCallback);

--- a/backend/routes/users/users.controller.js
+++ b/backend/routes/users/users.controller.js
@@ -3,6 +3,21 @@ const jwt = require('jsonwebtoken');
 const { User } = require('../../models');
 const asyncHandler = require('../../lib/asyncHandler');
 
+exports.getLoggedInUser = asyncHandler(async (req, res, next) => {
+  const {
+    id, email, nickname, profile_url,
+  } = res.locals.user;
+
+  res.json({
+    success: true,
+    content: {
+      user: {
+        id, email, nickname, profile_url,
+      },
+    },
+  });
+});
+
 exports.getAllUsers = asyncHandler(async (req, res, next) => {
   const users = await User.findAll({
     attributes: ['id', 'nickname', 'profile_url'],

--- a/backend/routes/users/users.controller.js
+++ b/backend/routes/users/users.controller.js
@@ -39,6 +39,6 @@ exports.githubLoginCallback = (req, res, next) => {
 
     const options = { httpOnly: true };
     res.cookie('authorization', token, options);
-    return res.redirect('/#/issues');
+    return res.redirect('/');
   })(req, res, next);
 };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { HashRouter as Router } from 'react-router-dom';
-// import Header from './components/Header';
 import Routes from './routes';
+import UserProvider from './lib/userProvider';
 
 function App() {
   return (
-    <Router>
-      {/* <Header /> */}
-      <Routes />
-    </Router>
+    <UserProvider>
+      <Router>
+        <Routes/>
+      </Router>
+    </UserProvider>
   );
 }
 

--- a/frontend/src/constants/api.js
+++ b/frontend/src/constants/api.js
@@ -1,5 +1,6 @@
 const apiUri = {
   login: '/users/github-login',
+  profile: '/users/me',
   issues: '/issues',
   labels: '/labels',
   milestones: '/milestones',

--- a/frontend/src/lib/useAuth.js
+++ b/frontend/src/lib/useAuth.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+import apiUri from '../constants/api';
+
+function useAuth() {
+  const [user, setUser] = useState(null);
+
+  const getLoggedInUser = () => {
+    fetch(apiUri.profile)
+      .then((res) => res.json())
+      .then((res) => {
+        if (res.success) {
+          setUser(res.content.user);
+        }
+      });
+  };
+
+  useEffect(getLoggedInUser, []);
+
+  return user;
+}
+
+export default useAuth;

--- a/frontend/src/lib/userContext.js
+++ b/frontend/src/lib/userContext.js
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+const UserContext = createContext(null);
+export default UserContext;

--- a/frontend/src/lib/userProvider.js
+++ b/frontend/src/lib/userProvider.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import useAuth from './useAuth';
+import UserContext from './userContext';
+
+function UserProvider({ children }) {
+  const user = useAuth();
+  return (
+    <UserContext.Provider value={user}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+
+export default UserProvider;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,12 +1,21 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { Redirect } from 'react-router-dom';
 import GlobalStyle from '../assets/styles/GlobalStyle';
 import LoginContainer from '../containers/login/LoginContainer';
+import userContext from '../lib/userContext';
+import pathUri from '../constants/path';
 
-const Login = () => (
-  <>
-    <GlobalStyle bg="#f6f8fa"/>
-    <LoginContainer/>
-  </>
-);
+const Login = () => {
+  const user = useContext(userContext);
+
+  if (user) return <Redirect to={pathUri.issue}/>;
+
+  return (
+    <>
+      <GlobalStyle bg="#f6f8fa"/>
+      <LoginContainer/>
+    </>
+  );
+};
 
 export default Login;


### PR DESCRIPTION
## 구현 내용
- BE 로그인된 유저의 정보 반환하는 `/users/me` api 추가
- userAuth : user를 state로 갖고 초기 렌더링 시에 server로 현재 로그인된 유저의 정보를 받아 setUser하는 hook
- userContext: user 정보를 제공하는 context
- userProvider : useAuth로 user 정보를 갖고 userContext로 하위 컴포넌트에 user 상태 제공하는 컴포넌트
- Login 페이지에서 로그인 된 상태일 때 issue 페이지로 전환하도록 구현 
    - Login 컴포넌트에서 userContext로 user 정보 받아오고 user가 있을 시에 Redirect 컴포넌트로 issue 페이지로 전환

### userContext에 저장되는 user example
```
"user": {
      "id": 3,
      "email": "chiy323@gmail.com",
      "nickname": "YimJiYoung",
      "profile_url": "https://avatars2.githubusercontent.com/u/37496919?v=4"
    }
```

### userContext 사용 방법
```javascript
import userContext from '../lib/userContext';

const Login = () => {
  const user = useContext(userContext);
};
```

## Notes
- 로그인 된 유저만 접근할 수 있는 PrivateRoute를 구현하는 것이 좋을 것 같아 이슈로 등록해두었음