### PR TITLE
FE 마일스톤 목록 화면 구현

### DIFF
--- a/backend/routes/milestones/milestones.controller.js
+++ b/backend/routes/milestones/milestones.controller.js
@@ -4,7 +4,7 @@ const asyncHandler = require('../../lib/asyncHandler');
 exports.list = asyncHandler(async (req, res, next) => {
   const milestones = await Milestone.findAll({
     attributes: [
-      'id', 'title', 'description', 'due_date',
+      'id', 'title', 'description', 'due_date', 'is_open',
       [sequelize.literal('SUM(issues.is_open)'), 'open_issues'],
       [sequelize.literal('SUM(issues.is_open=0)'), 'closed_issues'],
       [sequelize.literal('SUM(issues.is_open=0)/COUNT(*)'), 'progress'],

--- a/frontend/src/assets/icon/CalendarIcon.js
+++ b/frontend/src/assets/icon/CalendarIcon.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const CalendarIcon = () => (
+  <svg className="octicon octicon-calendar" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
+    <path fillRule="evenodd" d="M4.75 0a.75.75 0 01.75.75V2h5V.75a.75.75 0 011.5 0V2h1.25c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0113.25 16H2.75A1.75 1.75 0 011 14.25V3.75C1 2.784 1.784 2 2.75 2H4V.75A.75.75 0 014.75 0zm0 3.5h8.5a.25.25 0 01.25.25V6h-11V3.75a.25.25 0 01.25-.25h2zm-2.25 4v6.75c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25V7.5h-11z" />
+  </svg>
+);
+
+export default CalendarIcon;

--- a/frontend/src/components/ProgressBar.js
+++ b/frontend/src/components/ProgressBar.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const ProgressBarBase = styled.span`
+    display: flex;
+    background-color: #E9E9E9;
+    border-radius: 2em;
+    height: 8px;
+    width: 100%;
+    margin-bottom: 7px;
+    overflow: hidden;
+`;
+
+const Progress = styled.span`
+    display: block;
+    background-color: #28a745;
+    width: ${(props) => props.percent}%;
+`;
+
+const ProgressBar = ({ percent }) => (
+  <ProgressBarBase>
+    <Progress percent={percent} />
+  </ProgressBarBase>
+);
+
+export default ProgressBar;

--- a/frontend/src/constants/path.js
+++ b/frontend/src/constants/path.js
@@ -4,6 +4,7 @@ const pathUri = {
   createIssue: '/issues/new',
   issueDetail: '/issues/:id',
   milestone: '/milestones',
+  createMilestone: '/milestones/new',
   label: '/labels',
 };
 

--- a/frontend/src/containers/milestone-list/MilestoneListContainer.js
+++ b/frontend/src/containers/milestone-list/MilestoneListContainer.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+import NavBar from '@components/NavBar';
+import NewButton from '@components/NewButton';
+import useMilestones from '@lib/useMilestones';
+import pathUri from '@constants/path';
+import MilestoneList from './components/MilestoneList';
+
+const NavBarBox = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
+`;
+
+const ContentBox = styled.div`
+    padding: 10px 50px;
+`;
+
+const MilestoneListContainer = () => {
+  const milestones = useMilestones();
+
+  const handleClick = () => {
+    window.location.href = `/#${pathUri.createMilestone}`;
+  };
+
+  return (
+    <ContentBox>
+      <NavBarBox>
+        <NavBar/>
+        <NewButton handleClick={handleClick}>New milestone</NewButton>
+      </NavBarBox>
+      <MilestoneList milestones={milestones}/>
+    </ContentBox>
+  );
+};
+
+export default MilestoneListContainer;

--- a/frontend/src/containers/milestone-list/components/Button.js
+++ b/frontend/src/containers/milestone-list/components/Button.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Button = ({ onClick, text, style }) => (
+  <button type="button" onClick={onClick} style={style}>
+    {text}
+  </button>
+);
+
+export default Button;

--- a/frontend/src/containers/milestone-list/components/MilestoneItem.js
+++ b/frontend/src/containers/milestone-list/components/MilestoneItem.js
@@ -1,19 +1,52 @@
 import React from 'react';
 import styled from 'styled-components';
+import CalendarIcon from '@assets/icon/CalendarIcon';
+import formalizeDateString from '@lib/formalizeDateString';
+import ProgressBar from '@components/ProgressBar';
+import pathUri from '@constants/path';
+import Button from './Button';
 
 const ItemBox = styled.div`
     display: flex;
     justify-content: space-between;
     padding: 16px;
     border: 1px solid #e1e4e8;
+    color: #636363;
 `;
 
 const MilestoneContent = styled.div`
-    flex: 1;
+  flex: 4;
 `;
 
 const MilestoneSummary = styled.div`
-    flex: 1;
+  flex: 3;
+`;
+
+const Title = styled.a`
+  font-size: 1.6rem;
+  color: black;
+  :hover {
+    color: #1A60F5;
+    text-decoration: underline;
+  }
+`;
+
+const Content = styled.div`
+  margin-top: 5px;
+`;
+
+const StatusWrapper = styled.span`
+  margin-right: 15px;
+`;
+
+const StatusFigure = styled.span`
+  font-weight: 600;
+  margin-right: 5px;
+  color: black;
+`;
+
+const IconWrapper = styled.span`
+  margin-right: 4px;
 `;
 
 const MilestoneItem = ({ milestone }) => {
@@ -21,10 +54,59 @@ const MilestoneItem = ({ milestone }) => {
     id, title, description, due_date, is_open, open_issues, closed_issues, progress,
   } = milestone;
 
+  const percent = (progress * 100).toFixed(0);
+
+  const onEditClick = () => {
+    window.location.href = `/#${pathUri.milestone}/edit/${id}`;
+  };
+
+  const onCloseClick = () => {
+    // TOOD : 마일스톤 close 기능 구현
+    console.log('close milestone');
+  };
+
+  const onDeleteClick = () => {
+    // TOOD : 마일스톤 delete 기능 구현
+    console.log('delete milestone');
+  };
+
+  const blueWhiteButtonStyle = { all: 'unset', color: 'rgb(3, 102, 214)', padding: '5px 15px 5px 0' };
+  const redWhiteButtonStyle = { all: 'unset', color: 'rgb(203, 36, 49)', padding: '5px 15px 5px 0' };
+
   return (
     <ItemBox>
-      <MilestoneContent>content</MilestoneContent>
-      <MilestoneSummary>summary</MilestoneSummary>
+      <MilestoneContent>
+        <Title href={`/#${pathUri.milestone}/${id}`}>{title}</Title>
+        <Content>
+          <IconWrapper><CalendarIcon/></IconWrapper>
+          {' Due by '}
+          {formalizeDateString(due_date)}
+        </Content>
+        <Content>{description}</Content>
+      </MilestoneContent>
+
+      <MilestoneSummary>
+        <ProgressBar percent={percent} />
+        <Content>
+          <StatusWrapper>
+            <StatusFigure>{`${percent}%`}</StatusFigure>
+            complete
+          </StatusWrapper>
+          <StatusWrapper>
+            <StatusFigure>{open_issues || 0}</StatusFigure>
+            open
+          </StatusWrapper>
+          <StatusWrapper>
+            <StatusFigure>{closed_issues || 0}</StatusFigure>
+            closed
+          </StatusWrapper>
+        </Content>
+        <Content>
+          <Button onClick={onEditClick} text="Edit" style={blueWhiteButtonStyle}/>
+          <Button onClick={onCloseClick} text="Close" style={blueWhiteButtonStyle}/>
+          <Button onClick={onDeleteClick} text="Delete" style={redWhiteButtonStyle}/>
+        </Content>
+      </MilestoneSummary>
     </ItemBox>
   );
 };

--- a/frontend/src/containers/milestone-list/components/MilestoneItem.js
+++ b/frontend/src/containers/milestone-list/components/MilestoneItem.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const ItemBox = styled.div`
+    display: flex;
+    justify-content: space-between;
+    padding: 16px;
+    border: 1px solid #e1e4e8;
+`;
+
+const MilestoneContent = styled.div`
+    flex: 1;
+`;
+
+const MilestoneSummary = styled.div`
+    flex: 1;
+`;
+
+const MilestoneItem = ({ milestone }) => {
+  const {
+    id, title, description, due_date, is_open, open_issues, closed_issues, progress,
+  } = milestone;
+
+  return (
+    <ItemBox>
+      <MilestoneContent>content</MilestoneContent>
+      <MilestoneSummary>summary</MilestoneSummary>
+    </ItemBox>
+  );
+};
+
+export default MilestoneItem;

--- a/frontend/src/containers/milestone-list/components/MilestoneList.js
+++ b/frontend/src/containers/milestone-list/components/MilestoneList.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled from 'styled-components';
+import MilestoneIcon from '@assets/icon/MilestoneIcon';
+import CheckIcon from '@assets/icon/CheckIcon';
+import MilestoneItem from './MilestoneItem';
+
+const ListWrapper = styled.div`
+    border-radius: 6px;
+`;
+
+const ListHeader = styled.div`
+    background-color: #f6f8fa;
+    padding: 16px;
+    border: 1px solid #e1e4e8;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+`;
+
+const ListHeaderTab = styled.span`
+  color: ${(props) => (props.active ? 'black' : '#636363')};
+  font-weight: ${(props) => (props.active ? '600' : 'normal')};
+  margin-right: 17px;
+`;
+
+const IconWrapper = styled.span`
+  margin-right: 5px;
+`;
+
+const MilestoneList = ({ milestones }) => {
+  const openCount = milestones.filter((val) => val.is_open === 1).length;
+  const closeCount = milestones.filter((val) => val.is_open === 0).length;
+
+  const openActive = true;
+
+  // eslint-disable-next-line max-len
+  const milestoneList = milestones.map((milestone) => <MilestoneItem key={milestone.id} milestone={milestone} />);
+
+  return (
+    <ListWrapper>
+      <ListHeader>
+        <ListHeaderTab active={openActive}>
+          <IconWrapper><MilestoneIcon/></IconWrapper>
+          {openCount}
+          {' Open'}
+        </ListHeaderTab>
+        <ListHeaderTab active={!openActive}>
+          <IconWrapper><CheckIcon/></IconWrapper>
+          {closeCount}
+          {' Closed'}
+        </ListHeaderTab>
+      </ListHeader>
+
+      {milestoneList}
+    </ListWrapper>
+  );
+};
+
+export default MilestoneList;

--- a/frontend/src/containers/sidebar-form/components/MilestoneItem.js
+++ b/frontend/src/containers/sidebar-form/components/MilestoneItem.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import CheckIcon from '../../../assets/icon/CheckIcon';
+import formalizeDateString from '@lib/formalizeDateString';
 
 const Item = styled.li`
   all: unset;
@@ -29,11 +30,6 @@ const CheckIconWrapper = styled.div`
   right: 92%;
   visibility: ${(props) => (props.visible ? 'visible' : 'hidden')};
 `;
-
-const formalizeDateString = (dueDate) => {
-  const options = { year: 'numeric', month: 'long', day: 'numeric' };
-  return dueDate ? new Date(dueDate).toLocaleString('en-US', options) : 'No due date';
-};
 
 const MilestoneItem = ({ milestone, onItemClick, selected }) => {
   const {

--- a/frontend/src/containers/sidebar-form/components/SelectedMilestoneItem.js
+++ b/frontend/src/containers/sidebar-form/components/SelectedMilestoneItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import ProgressBar from '@components/ProgressBar';
 
 const Wrapper = styled.div`
   margin: 8px 0;
@@ -9,22 +10,6 @@ const MilestoneTitle = styled.div`
   font-weight: bolder;
 `;
 
-const ProgressBarBase = styled.span`
-  display: flex;
-  background-color: #E9E9E9;
-  border-radius: 2em;
-  height: 8px;
-  width: 100%;
-  margin-bottom: 7px;
-  overflow: hidden;
-`;
-
-const Progress = styled.span`
-  display: block;
-  background-color: #28a745;
-  width: ${(props) => props.percent}%;
-`;
-
 const SelectedMilestoneItem = ({ milestone }) => {
   const {
     id, title, description, due_date: dueDate, open_issues: openIssues, closed_issues: closedIssues, progress,
@@ -32,9 +17,7 @@ const SelectedMilestoneItem = ({ milestone }) => {
 
   return (
     <Wrapper>
-      <ProgressBarBase>
-        <Progress percent={progress * 100} />
-      </ProgressBarBase>
+      <ProgressBar percent={progress * 100} />
       <MilestoneTitle>{title}</MilestoneTitle>
     </Wrapper>
   );

--- a/frontend/src/lib/formalizeDateString.js
+++ b/frontend/src/lib/formalizeDateString.js
@@ -1,0 +1,6 @@
+const formalizeDateString = (dueDate) => {
+  const options = { year: 'numeric', month: 'long', day: 'numeric' };
+  return dueDate ? new Date(dueDate).toLocaleString('en-US', options) : 'No due date';
+};
+
+export default formalizeDateString;

--- a/frontend/src/pages/MilestoneList.js
+++ b/frontend/src/pages/MilestoneList.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import GlobalStyle from '../assets/styles/GlobalStyle';
+import Header from '../components/Header';
+import MilestoneListContainer from '../containers/milestone-list/MilestoneListContainer';
+
+const MilestoneList = () => (
+  <>
+    <GlobalStyle/>
+    <Header/>
+    <MilestoneListContainer/>
+  </>
+);
+
+export default MilestoneList;

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -3,3 +3,4 @@ export { default as Issue } from './Issue';
 export { default as CreateIssue } from './CreateIssue';
 export { default as IssueDetail } from './IssueDetail';
 export { default as Label } from './Label';
+export { default as MilestoneList } from './MilestoneList';

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import pathUri from './constants/path';
+import pathUri from '@constants/path';
 import {
-  Login, Issue, CreateIssue, IssueDetail, Label,
+  Login, Issue, CreateIssue, IssueDetail, Label, MilestoneList,
 } from './pages';
 
 const routes = () => (
   <Switch>
     <Route exact path={pathUri.home} component={Login}/>
     <Route exact path={pathUri.createIssue} component={CreateIssue}/>
+    {/* <Route exact path={pathUri.createMilestone} component={CreateMilestone}/> */}
     <Route path={pathUri.issueDetail} component={IssueDetail}/>
     <Route path={pathUri.issue} component={Issue}/>
     <Route path={pathUri.label} component={Label}/>
+    <Route path={pathUri.milestone} component={MilestoneList}/>
   </Switch>
 );
 


### PR DESCRIPTION
## 구현 내용

<img width="1278" alt="스크린샷 2020-11-12 오후 5 47 41" src="https://user-images.githubusercontent.com/57661699/98917019-33e03180-250f-11eb-98b8-be7050f1493b.png">

###  마일스톤 목록 페이지 구현
- MilestoneListContainer.js : milestone 목록 렌더링
  - useMilestones 사용
- MilestoneItem.js : 마일스톤 목록의 각 item 컴포넌트

### formalizeDateString 함수 lib에 추가
- date -> 'November 10, 2020' 형식으로 바꿔주는 함수
- 마일스톤 컴포넌트 등에서 사용

### ProgressBar 공용 컴포넌트 추가
- 마일스톤 상태 표시에 사용


## Notes
- Edit, Close, Delete 핸들링은 미구현 상태입니다.
