### PR TITLE
FE 마일스톤 등록 화면 구현 / api 요청 연동

### DIFF
--- a/backend/routes/issues/index.js
+++ b/backend/routes/issues/index.js
@@ -9,5 +9,4 @@ issue.get('/:issueNumber', issuesController.detail);
 issue.post('/', authMiddleware, issuesController.create);
 issue.post('/update', authMiddleware, issuesController.update);
 
-
 module.exports = issue;

--- a/backend/routes/milestones/index.js
+++ b/backend/routes/milestones/index.js
@@ -1,9 +1,10 @@
 const express = require('express');
+const { authMiddleware } = require('../../middlewares/auth');
 const milestoneController = require('./milestones.controller');
 
 const router = express.Router();
 
 router.get('/', milestoneController.list);
-router.post('/', milestoneController.create);
+router.post('/', authMiddleware, milestoneController.create);
 
 module.exports = router;

--- a/frontend/src/constants/path.js
+++ b/frontend/src/constants/path.js
@@ -4,6 +4,7 @@ const pathUri = {
   createIssue: '/issues/new',
   issueDetail: '/issues/:id',
   milestone: '/milestones',
+  createMilestone: '/milestones/new',
   label: '/labels',
 };
 

--- a/frontend/src/containers/issue-form/IssueMainForm.js
+++ b/frontend/src/containers/issue-form/IssueMainForm.js
@@ -45,6 +45,7 @@ const Wrapper = styled.div`
 
 const IssueMainForm = ({ user, onChange, onFileUpload, onSubmit, issue }) => {
   const { title, description } = issue;
+
   return (
     <Wrapper>
       <UserProfileContainer user={user} />
@@ -54,7 +55,7 @@ const IssueMainForm = ({ user, onChange, onFileUpload, onSubmit, issue }) => {
         <CommentEditor name="description" onChange={onChange} onFileUpload={onFileUpload} value={description} />
         <FlexRowBetween>
           <CancelButton path="/#/issues" />
-          <SubmitButton onClick={onSubmit} target={issue} />
+          <SubmitButton onClick={onSubmit} target={title} text="Submit new Issue" />
         </FlexRowBetween>
       </IssueFormBox>
     </Wrapper>

--- a/frontend/src/containers/issue-form/components/SubmitButton.js
+++ b/frontend/src/containers/issue-form/components/SubmitButton.js
@@ -15,8 +15,8 @@ const Button = styled.button`
 `;
 
 // eslint-disable-next-line arrow-body-style
-const SubmitButton = ({ onClick, target }) => {
-  return <Button type="submit" value="Submit" onClick={onClick} disabled={target.title === '' || target.description === ''}>Submit new Issue</Button>;
+const SubmitButton = ({ onClick, target, text }) => {
+  return <Button type="submit" value="Submit" onClick={onClick} disabled={target === ''}>{text}</Button>;
 };
 
 export default SubmitButton;

--- a/frontend/src/containers/milestone-form/MilestoneFormContainer.js
+++ b/frontend/src/containers/milestone-form/MilestoneFormContainer.js
@@ -1,0 +1,169 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import apiUri from '@constants/api';
+import pathUri from '@constants/path';
+import CancelButton from '@containers/issue-form/components/CancelButton';
+import SubmitButton from '@containers/issue-form/components/SubmitButton';
+
+const Input = styled.input`
+  display: block;
+  width: 100%;
+  padding: 7px 10px;
+  background-color: #FAFAFA;
+  border: 1px solid lightgray;
+  border-radius: 5px;
+  font-size: 18px;
+  :focus {
+    background-color: white;
+    border-color: blue;
+    outline: none;
+    box-shadow: 0 0 0 3px #B9D9E8;
+  }
+`;
+
+const Textarea = styled.textarea`
+  width: 100%;
+  height: 200px;
+  padding: 10px;
+  background-color: #FAFAFA;
+  border: 1px solid lightgray;
+  border-radius: 5px;
+  font-size: 18px;
+  resize: vertical;
+  :focus {
+    background-color: white;
+    border-color: blue;
+    outline: none;
+    box-shadow: 0 0 0 3px #B9D9E8;
+  }
+`;
+
+const FormButtons = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  flex-wrap: wrap;
+  border-top: 1px solid lightgray;
+  padding: 10px 0;
+`;
+
+const Header = styled.div`
+  padding-bottom: 20px;
+  border-bottom: 1px solid lightgray;
+`;
+const HeaderTitle = styled.h2`
+  margin: 7px 0;
+`;
+const Explanation = styled.div`
+  color: gray;
+`;
+
+const MilestoneFormWrapper = styled.div`
+  margin: 10px 0;
+`;
+
+const InputWrapper = styled.div`
+    margin: 18px 0px;
+    max-width: 650px;
+`;
+
+const Label = styled.label`
+    display: block;
+    width: 250px;
+    font-size: 16px;
+    font-weight: 600;
+    margin: 5px;
+`;
+
+const MilestoneFormContainer = ({ milestone }) => {
+  const {
+    id, title, description, due_date, is_open,
+  } = milestone || {};
+
+  const [mTitle, setMTitle] = useState(title || '');
+  const [mDueDate, setMDueDate] = useState(due_date || '');
+  const [mDescription, setMDescription] = useState(description || '');
+
+  const onChange = (e) => {
+    const { name, value } = e.target;
+    switch (name) {
+      case 'mDueDate':
+        setMDueDate(value);
+        break;
+      case 'mTitle':
+        setMTitle(value);
+        break;
+      case 'mDescription':
+        setMDescription(value);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+
+    const milestoneData = {
+      title: mTitle,
+      description: mDescription,
+      due_date: mDueDate,
+    };
+
+    const response = await fetch(apiUri.milestones, {
+      mode: 'cors',
+      credentials: 'include',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(milestoneData),
+    });
+
+    const { success, content, message } = await response.json();
+    if (!success) {
+      alert(message);
+      return;
+    }
+
+    window.location.href = `/#${pathUri.milestone}`;
+  };
+
+  return (
+    <>
+      <Header>
+        <HeaderTitle>New milestone</HeaderTitle>
+        <Explanation>
+          Create a new milestone to held organize your issues and pull requests.
+          Learn more about milestones and issues.
+        </Explanation>
+      </Header>
+
+      <MilestoneFormWrapper>
+        <form onSubmit={onSubmit}>
+          <InputWrapper>
+            <Label htmlFor="mTitle">Title</Label>
+            <Input type="text" name="mTitle" id="mTitle" placeholder="Title" onChange={onChange} value={mTitle} />
+          </InputWrapper>
+
+          <InputWrapper>
+            <Label htmlFor="mDueDate">Due date (optional)</Label>
+            <Input type="date" name="mDueDate" id="mDueDate" onChange={onChange} value={mDueDate} />
+          </InputWrapper>
+
+          <InputWrapper>
+            <Label htmlFor="mDescription">Description</Label>
+            <Textarea name="mDescription" id="mDescription" onChange={onChange} value={mDescription} />
+          </InputWrapper>
+
+          <FormButtons>
+            <CancelButton path={`/#${pathUri.milestone}`} />
+            <SubmitButton onClick={onSubmit} target={mTitle} text="Create milestone"/>
+          </FormButtons>
+        </form>
+      </MilestoneFormWrapper>
+    </>
+  );
+};
+
+export default MilestoneFormContainer;

--- a/frontend/src/pages/CreateMilestone.js
+++ b/frontend/src/pages/CreateMilestone.js
@@ -1,0 +1,25 @@
+import React, { useContext } from 'react';
+import { Redirect } from 'react-router-dom';
+import GlobalStyle from '@assets/styles/GlobalStyle';
+import Header from '@components/Header';
+import userContext from '@lib/userContext';
+import pathUri from '@constants/path';
+import MilestoneFormContainer from '@containers/milestone-form/MilestoneFormContainer';
+
+const CreateMilestone = () => {
+  const user = useContext(userContext);
+
+  if (!user) return <Redirect to={pathUri.home}/>;
+
+  return (
+    <>
+      <GlobalStyle/>
+      <Header/>
+      <div style={{ padding: '0 3%', backgroundColor: 'white' }}>
+        <MilestoneFormContainer />
+      </div>
+    </>
+  );
+};
+
+export default CreateMilestone;

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -3,3 +3,4 @@ export { default as Issue } from './Issue';
 export { default as CreateIssue } from './CreateIssue';
 export { default as IssueDetail } from './IssueDetail';
 export { default as Label } from './Label';
+export { default as CreateMilestone } from './CreateMilestone';

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import pathUri from './constants/path';
+import pathUri from '@constants/path';
 import {
-  Login, Issue, CreateIssue, IssueDetail, Label,
+  Login, Issue, CreateIssue, IssueDetail, Label, CreateMilestone,
 } from './pages';
 
 const routes = () => (
   <Switch>
     <Route exact path={pathUri.home} component={Login}/>
     <Route exact path={pathUri.createIssue} component={CreateIssue}/>
+    <Route exact path={pathUri.createMilestone} component={CreateMilestone}/>
     <Route path={pathUri.issueDetail} component={IssueDetail}/>
     <Route path={pathUri.issue} component={Issue}/>
     <Route path={pathUri.label} component={Label}/>


### PR DESCRIPTION
## 구현 내용

<img width="1280" alt="스크린샷 2020-11-12 오후 7 35 50" src="https://user-images.githubusercontent.com/57661699/98929315-4dd54080-251e-11eb-9ed8-71603117a2fc.png">


### milestone 등록 화면 구현
- frontend/src/pages/CreateMilestone.js : MilestoneFormContainer를 렌더링하는 페이지
- frontend/src/containers/milestone-form/
  - MilestoneFormContainer.js : 마일스톤 form 컨테이너
    - onSubmit 시 POST /milestones 요청(마일스톤 생성) -> 요청 완료 시 마일스톤 목록 화면으로 이동
    - milestone을 받아 값이 존재하면 수정 form으로 사용할 수 있도록 할 예정(생성 화면에선 milestone 데이터를 전달받지 않음)

###  milestone 생성 api 수정
- POST /milestones 요청 시 auth 미들웨어 인증


## Notes
- issue-form 관련 리팩토링 : SubmitButton 컴포넌트 수정
  - 마일스톤 폼 컨테이너에서도 재사용 할 수 있도록 수정했습니다.
